### PR TITLE
Include path has -IMarlin

### DIFF
--- a/src/MarlinSimulator/hardware/ST7796Device.cpp
+++ b/src/MarlinSimulator/hardware/ST7796Device.cpp
@@ -11,8 +11,9 @@
 
 #include "ST7796Device.h"
 
-#include <src/HAL/NATIVE_SIM/tft/xpt2046.h>
-#include <src/HAL/NATIVE_SIM/tft/tft_spi.h>
+#include "../paths.h"
+#include MARLIN_HAL_PATH(tft/xpt2046.h)
+#include MARLIN_HAL_PATH(tft/tft_spi.h)
 
 #define ST7796S_CASET      0x2A // Column Address Set
 #define ST7796S_RASET      0x2B // Row Address Set

--- a/src/MarlinSimulator/hardware/XPT2046Device.cpp
+++ b/src/MarlinSimulator/hardware/XPT2046Device.cpp
@@ -7,7 +7,9 @@
 #include <gl.h>
 
 #include "XPT2046Device.h"
-#include <src/HAL/NATIVE_SIM/tft/xpt2046.h>
+
+#include "../paths.h"
+#include MARLIN_HAL_PATH(tft/xpt2046.h)
 #if ENABLED(TOUCH_SCREEN)
   #include <src/lcd/tft/touch.h>
 #else

--- a/src/MarlinSimulator/marlin_hal_impl/tft/tft_spi.cpp
+++ b/src/MarlinSimulator/marlin_hal_impl/tft/tft_spi.cpp
@@ -24,7 +24,8 @@
 
 #if HAS_SPI_TFT
 
-#include HAL_PATH(src, tft/tft_spi.h)
+#include "../../paths.h"
+#include MARLIN_HAL_PATH(tft/tft_spi.h)
 #include "../../hardware/bus/spi.h"
 
 static SpiBus &spi_bus = spi_bus_by_pins<TFT_SCK_PIN, TFT_MOSI_PIN, TFT_MISO_PIN>();

--- a/src/MarlinSimulator/marlin_hal_impl/tft/xpt2046.cpp
+++ b/src/MarlinSimulator/marlin_hal_impl/tft/xpt2046.cpp
@@ -21,7 +21,8 @@
 
 #if HAS_TFT_XPT2046 || HAS_TOUCH_XPT2046
 
-#include HAL_PATH(src/HAL, tft/xpt2046.h)
+#include "../../paths.h"
+#include MARLIN_HAL_PATH(tft/xpt2046.h)
 #include "../../hardware/bus/spi.h"
 
 static SpiBus &spi_bus = spi_bus_by_pins<TOUCH_SCK_PIN, TOUCH_MOSI_PIN, TOUCH_MISO_PIN>();

--- a/src/MarlinSimulator/paths.h
+++ b/src/MarlinSimulator/paths.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#ifndef SIMHAL
+  #define SIMHAL NATIVE_SIM
+#endif
+#define MARLIN_HAL_PATH(FILE) <src/HAL/SIMHAL/FILE>

--- a/src/MarlinSimulator/virtual_printer.cpp
+++ b/src/MarlinSimulator/virtual_printer.cpp
@@ -21,7 +21,8 @@
 #include <src/inc/MarlinConfig.h>
 
 #if HAS_TFT_XPT2046 || HAS_TOUCH_XPT2046
-  #include HAL_PATH(src/HAL, tft/xpt2046.h)
+  #include "paths.h"
+  #include MARLIN_HAL_PATH(tft/xpt2046.h)
 #endif
 
 #ifndef SD_DETECT_STATE


### PR DESCRIPTION
The project already uses `#include <...>` so I guess we can continue that trend. If the name of the HAL folder changes, we can add `-IMarlin/src/HAL/NEW_NAME` to the build flags and change `#include <src/HAL/NATIVE_SIM/header.h>` to `#include <header.h>`, adjusting header names to avoid coincidences with Arduino, etc.